### PR TITLE
debian 8.2 and fallout

### DIFF
--- a/debian/debian77-vagrant.json
+++ b/debian/debian77-vagrant.json
@@ -1,0 +1,71 @@
+{
+    "variables": {
+        "user": "vagrant",
+        "password": "vagrant",
+        "disk_size": "100000",
+        "domain": ""
+    },
+
+    "builders":
+    [
+        {
+            "name": "debian77-vagrant",
+
+            "type": "qemu",
+            "format": "qcow2",
+            "accelerator": "kvm",
+            "disk_size": "{{ user `disk_size`}}",
+
+            "iso_url": "http://cdimage.debian.org/debian-cd/7.7.0/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso",
+            "iso_checksum": "0b31bccccb048d20b551f70830bb7ad0",
+            "iso_checksum_type": "md5",
+
+            "http_directory": "http",
+
+            "ssh_username": "{{user `user`}}",
+            "ssh_password": "{{user `password`}}",
+            "shutdown_command": "echo '{{user `password`}}'|sudo -S shutdown -h now",
+
+            "boot_wait": "2s",
+            "boot_command": [
+                   "<esc><wait><wait>",
+                   "install auto ",
+                   "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+                   "debian-installer=en_US locale=en_US keymap=us ",
+                   "netcfg/get_hostname={{ .Name }} ",
+                   "netcfg/get_domain={{ user `domain`}} ",
+
+                   "fb=false debconf/frontend=noninteractive ",
+
+                   "passwd/user-fullname={{user `user`}} ",
+                   "passwd/user-password={{user `password`}} ",
+                   "passwd/user-password-again={{user `password`}} ",
+                   "passwd/username={{user `user`}} ",
+
+                   "<enter>"
+            ]
+        }
+    ],
+
+    "provisioners": [
+        {
+            "type": "shell",
+            "execute_command": "echo '{{user `password`}}' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+            "scripts": [
+                "scripts/update.sh",
+                "scripts/packages.sh",
+                "scripts/vagrant.sh",
+                "scripts/cleanup.sh"
+            ]
+        }
+    ],
+
+    "post-processors": [
+        {
+            "keep_input_artifact": false,
+            "output": "box/debian77-vagrant.box",
+            "type": "vagrant"
+        }
+    ]
+
+}

--- a/debian/debian77.json
+++ b/debian/debian77.json
@@ -1,0 +1,61 @@
+{
+    "variables": {
+        "user": "admindebian",
+        "password": "admindebian",
+        "disk_size": "100000",
+        "domain": ""
+    },
+
+    "builders":
+    [
+        {
+            "name": "debian77",
+
+            "type": "qemu",
+            "format": "qcow2",
+            "accelerator": "kvm",
+            "disk_size": "{{ user `disk_size`}}",
+
+            "iso_url": "http://cdimage.debian.org/debian-cd/7.7.0/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso",
+            "iso_checksum": "0b31bccccb048d20b551f70830bb7ad0",
+            "iso_checksum_type": "md5",
+
+            "http_directory": "http",
+
+            "ssh_username": "{{user `user`}}",
+            "ssh_password": "{{user `password`}}",
+            "shutdown_command": "echo '{{user `password`}}'|sudo -S shutdown -h now",
+
+            "boot_wait": "2s",
+            "boot_command": [
+                   "<esc><wait><wait>",
+                   "install auto ",
+                   "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+                   "debian-installer=en_US locale=en_US keymap=us ",
+                   "netcfg/get_hostname={{ .Name }} ",
+                   "netcfg/get_domain={{ user `domain`}} ",
+
+                   "fb=false debconf/frontend=noninteractive ",
+
+                   "passwd/user-fullname={{user `user`}} ",
+                   "passwd/user-password={{user `password`}} ",
+                   "passwd/user-password-again={{user `password`}} ",
+                   "passwd/username={{user `user`}} ",
+
+                   "<enter>"
+            ]
+        }
+    ],
+
+    "provisioners": [
+        {
+            "type": "shell",
+            "execute_command": "echo '{{user `password`}}' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+            "scripts": [
+                "scripts/update.sh",
+                "scripts/packages.sh",
+                "scripts/cleanup.sh"
+            ]
+        }
+    ]
+}

--- a/debian/debian82-vagrant.json
+++ b/debian/debian82-vagrant.json
@@ -1,23 +1,23 @@
 {
     "variables": {
-        "user": "admindebian",
-        "password": "admindebian",
-        "disk_size": 100000,
+        "user": "vagrant",
+        "password": "vagrant",
+        "disk_size": "100000",
         "domain": ""
     },
 
     "builders":
     [
         {
-            "name": "debian77",
+            "name": "debian82-vagrant",
 
             "type": "qemu",
             "format": "qcow2",
             "accelerator": "kvm",
             "disk_size": "{{ user `disk_size`}}",
 
-            "iso_url": "http://cdimage.debian.org/debian-cd/7.7.0/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso",
-            "iso_checksum": "0b31bccccb048d20b551f70830bb7ad0",
+            "iso_url": "http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso",
+            "iso_checksum": "762eb3dfc22f85faf659001ebf270b4f",
             "iso_checksum_type": "md5",
 
             "http_directory": "http",
@@ -25,6 +25,8 @@
             "ssh_username": "{{user `user`}}",
             "ssh_password": "{{user `password`}}",
             "shutdown_command": "echo '{{user `password`}}'|sudo -S shutdown -h now",
+
+            "ssh_wait_timeout": "60m",
 
             "boot_wait": "2s",
             "boot_command": [
@@ -54,8 +56,18 @@
             "scripts": [
                 "scripts/update.sh",
                 "scripts/packages.sh",
+                "scripts/vagrant.sh",
                 "scripts/cleanup.sh"
             ]
         }
+    ],
+
+    "post-processors": [
+        {
+            "keep_input_artifact": false,
+            "output": "box/debian82-vagrant.box",
+            "type": "vagrant"
+        }
     ]
+
 }

--- a/debian/debian82.json
+++ b/debian/debian82.json
@@ -1,23 +1,23 @@
 {
     "variables": {
-        "user": "vagrant",
-        "password": "vagrant",
-        "disk_size": 100000,
+        "user": "admindebian",
+        "password": "admindebian",
+        "disk_size": "100000",
         "domain": ""
     },
 
     "builders":
     [
         {
-            "name": "debian77-vagrant",
+            "name": "debian82",
 
             "type": "qemu",
             "format": "qcow2",
             "accelerator": "kvm",
             "disk_size": "{{ user `disk_size`}}",
 
-            "iso_url": "http://cdimage.debian.org/debian-cd/7.7.0/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso",
-            "iso_checksum": "0b31bccccb048d20b551f70830bb7ad0",
+            "iso_url": "http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso",
+            "iso_checksum": "762eb3dfc22f85faf659001ebf270b4f",
             "iso_checksum_type": "md5",
 
             "http_directory": "http",
@@ -25,6 +25,8 @@
             "ssh_username": "{{user `user`}}",
             "ssh_password": "{{user `password`}}",
             "shutdown_command": "echo '{{user `password`}}'|sudo -S shutdown -h now",
+
+            "ssh_wait_timeout": "60m",
 
             "boot_wait": "2s",
             "boot_command": [
@@ -54,18 +56,8 @@
             "scripts": [
                 "scripts/update.sh",
                 "scripts/packages.sh",
-                "scripts/vagrant.sh",
                 "scripts/cleanup.sh"
             ]
         }
-    ],
-
-    "post-processors": [
-        {
-            "keep_input_artifact": false,
-            "output": "box/debian77-vagrant.box",
-            "type": "vagrant"
-        }
     ]
- 
 }

--- a/debian/http/preseed.cfg
+++ b/debian/http/preseed.cfg
@@ -1,6 +1,7 @@
 d-i clock-setup/ntp boolean true
 d-i clock-setup/utc boolean true
 d-i finish-install/reboot_in_progress note
+d-i grub-installer/bootdev string default
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
 d-i mirror/country string manual


### PR DESCRIPTION
Hi Jakob,

first of all: Thank you very much for sharing these templates!

Here are some adjustments I had to make to build Debian 8.2 images - besides from the new URLs/checksums, I 
 * added a new value `grub-installer/bootdev` to `preseed.cfg` - Debian 8 seems to need this
 * changed the `disk_size` variable to be a string - same as in the pull request https://github.com/jakobadam/packer-qemu-templates/pull/3, I believe. Without this change, packer returns `Failed to parse template: 1 error(s) occurred: variable disk_size: '' expected type 'string', got unconvertible type 'float64'`
 * added `ssh_wait_timeout` because otherwise I'd run into a timeout during the build.

Hope this makes sense...let me know if not ;-)

Cheers,
Philipp

PS: FWIW - using Packer 0.8.6 on Ubuntu 15.04.