### PR TITLE
adding headless building

### DIFF
--- a/ubuntu/ubuntu-16.04-server-amd64.json
+++ b/ubuntu/ubuntu-16.04-server-amd64.json
@@ -12,6 +12,7 @@
 
             "type": "qemu",
             "format": "qcow2",
+	    "headless": "true",
             "accelerator": "kvm",
             "disk_size": "{{ user `disk_size`}}",
 


### PR DESCRIPTION
Basically if you run **packer build** remotely, you will get an error like

```
==> ubuntu-1604-server-vagrant: Error launching VM: Qemu failed to start. Please run with logs to get more info.
==> ubuntu-1604-server-vagrant: Deleting output directory...
Build 'ubuntu-1604-server-vagrant' errored: Build was halted.
```

I propose to add headless configuration option
