### PR TITLE
Update Ubuntu ISO to 16.04.2

### DIFF
--- a/ubuntu/ubuntu1604.json
+++ b/ubuntu/ubuntu1604.json
@@ -3,9 +3,9 @@
   "vm_name": "ubuntu1604",
   "cpus": "1",
   "disk_size": "65536",
-  "iso_checksum": "29a8b9009509b39d542ecb229787cdf48f05e739a932289de9e9858d7c487c80",
+  "iso_checksum": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
+  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
   "memory": "512",
   "preseed" : "preseed.cfg",
   "version" : "1"


### PR DESCRIPTION
The current version was already failing for me because of checksum mismatch, so I thought directly updating the Ubuntu version would be nice as well :)