### PR TITLE
Fix issue#24 Debian8 IPv6 install DNS problem

### DIFF
--- a/debian/debian87.json
+++ b/debian/debian87.json
@@ -36,7 +36,6 @@
                    "priority=critical ",
                    "interface=auto ",
                    "url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
-                   "preseed/url/checksum=45ced8a80f86ceb26104c88800c1e1fa ",
 
                    "passwd/user-fullname={{ user `user` }} ",
                    "passwd/user-password={{ user `password` }} ",
@@ -53,6 +52,8 @@
             "type": "shell",
             "execute_command": "echo '{{ user `password` }}' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
             "scripts": [
+                "scripts/update.sh",
+                "scripts/packages.sh",
                 "scripts/cleanup.sh"
             ]
         }

--- a/debian/http/preseed.cfg
+++ b/debian/http/preseed.cfg
@@ -96,6 +96,12 @@ d-i grub-installer/with_other_os boolean true
 # To install to the first device (assuming it is not a USB stick):
 d-i grub-installer/bootdev  string default
 
+### Disable rdnssd if installed without resolvconf
+d-i preseed/late_command string \
+  if [ -x "/target/sbin/rdnssd" -a ! -x "/target/sbin/resolvconf" ] ; then \
+    in-target systemctl disable rdnssd.service ; \
+  fi
+
 ### Finishing up the installation
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note


### PR DESCRIPTION
If IPv6 detected Debian installer installs rdnssd without resolvconf
which in causes IPv4 nameservers to be dropped from /etc/resolv.conf.
update.sh and packages.sh fail. (Ref: Debian bug 767071)

- Added logic to debian/http/preseed.cfg to detect rdnssd and disable
  when resolvconf has not been installed

- Re-inserted update.sh and packages.sh in debian87.json

- Removed preseed url checksum from debian87.json. Recommend not
  to use since preseed.cfg defined in this closed environment.
