### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Introduction
+## Introduction
 
 The packer-qemu-templates provides Packer templates for unattended building of
 relevant virtual machine images in the qcow2 format for use with KVM.
@@ -7,15 +7,15 @@ In addition, all templates for use with Vagrant, through [vagrant-libvirt](https
 
 More info: http://blog.aarhusworks.com/unattended-installation-of-vm-images-with-packer/
 
-##Status
+## Status
 
 Currently the project includes templates for Ubuntu, CentOS, Debian and Windows. In other words, the OSes of the VMs I and the other contributors use on a day-to-day basis.
 
 Feel free to contribute more:-) 
 
-##Usage
+## Usage
 
-###Build qcow2 image
+### Build qcow2 image
 Go into the relevant template directory and run packer build on
 the relevant json file.
 
@@ -48,7 +48,7 @@ Get IP of machine
 $ vagrant ssh-config
 ```
 
-##Acknowledgements
+## Acknowledgements
 
 * [packer-images](https://github.com/opentable/packer-images.git)
 * [packer-windows](https://github.com/joefitzgerald/packer-windows)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
